### PR TITLE
Fix accommodation creation (fixes #35)

### DIFF
--- a/backend/cms/templates/accommodations/accommodation_form.html
+++ b/backend/cms/templates/accommodations/accommodation_form.html
@@ -129,9 +129,9 @@
             </ul>
             <div class="w-full mb-4 rounded border-2 border-solid border-blue-dark shadow bg-white">
                 <div class="p-4">
+                    {{ beds_formset.management_form }}
                     {% if accommodation_form.instance.id %}
                         {% if beds_formset.forms %}
-                            {{ beds_formset.management_form }}
                             <table class="w-full mt-4 rounded border border-solid border-grey-light shadow bg-white table-fixed">
                                 <thead>
                                 <tr class="border-b border-solid border-grey-light">


### PR DESCRIPTION
The beds formset is only included in the accommodation form if the accommodation exists already. This leaded to an error when the backend expects the management form of the formset to be present in the response. As a fix, the management form is now included, even if the actual bed formset is not.